### PR TITLE
Fix/fournisseur

### DIFF
--- a/app/Http/Controllers/StocksSortiesController.php
+++ b/app/Http/Controllers/StocksSortiesController.php
@@ -15,86 +15,11 @@ class StocksSortiesController extends Controller
     /**
      * Display a listing of the resource.
      */
-//     public function index()
-// {
-//     // Récupération des sorties de stock triées par date_sortie DESC
-//     $stocksSorties = StocksSorties::with(['produit', 'user'])
-//         ->orderBy('date_sortie', 'desc')
-//         ->orderBy('numero_bon', 'desc')
-//         ->get();
-
-//     // Groupement par numéro de bon
-//     $stocksSortiesGroupes = $stocksSorties->groupBy('numero_bon');
-
-//     $bonsSortie = [];
-
-//     foreach ($stocksSortiesGroupes as $bon => $sorties) {
-//         $firstSortie = $sorties->first();
-
-//         $bonsSortie[] = [
-//             'numero_bon' => $bon,
-//             'date_sortie' => $firstSortie->date_sortie,
-//             'statut' => $firstSortie->statut,
-//             'nombre_produits' => $sorties->count(),
-//             'user' => $firstSortie->user,
-//             'id' => $firstSortie->id,
-//         ];
-//     }
-
-//     // Tri final du tableau des bons par date_sortie desc (et éventuellement numero_bon desc)
-//     usort($bonsSortie, function ($a, $b) {
-//         return strcmp($b['date_sortie'], $a['date_sortie']) ?: strcmp($b['numero_bon'], $a['numero_bon']);
-//     });
-
-//     // Produits avec des stocks disponibles
-//     $produitsAvecStock = Produit::whereHas('stocksEntrees', function ($query) {
-//         $query->select('produit_id')->groupBy('produit_id');
-//     })->get()->filter(function ($produit) {
-//         $totalEntree = StocksEntrees::where('produit_id', $produit->id)->sum('quantite');
-//         $totalSortie = StocksSorties::where('produit_id', $produit->id)->sum('quantite');
-//         return ($totalEntree - $totalSortie) > 0;
-//     });
-
-//     // Lots disponibles
-//     $stocksEntreesDisponibles = StocksEntrees::with('produit')->get()->filter(function ($entree) {
-//         $totalSortie = StocksSorties::where('stock_entree_id', $entree->id)->sum('quantite');
-//         return ($entree->quantite - $totalSortie) > 0;
-//     });
-
-//     // Numéro automatique du bon
-//     $numeroBon = $this->genererNumeroBon();
-
-//     return view('stocksSorties.index', [
-//         'stocksSorties' => $bonsSortie,
-//         'produits' => $produitsAvecStock,
-//         'stocksEntrees' => $stocksEntreesDisponibles,
-//         'numeroBon' => $numeroBon,
-//         'id' => $bonsSortie[0]['id'] ?? null,
-//     ]);
-// }
-
-public function index(Request $request)
+    public function index()
 {
-    $mois = $request->input('mois', now()->month); // mois courant par défaut
-    $statut = $request->input('statut');
-    $utilisateur = $request->input('utilisateur');
-
-    $query = StocksSorties::with(['produit', 'user']);
-
-    // Filtrer par mois
-    $query->whereMonth('date_sortie', $mois);
-
-    // Filtrer par statut si fourni
-    if (!empty($statut)) {
-        $query->where('statut', $statut);
-    }
-
-    // Filtrer par utilisateur actuel si demandé
-    if ($utilisateur === 'moi') {
-        $query->where('user_id', Auth::id());
-    }
-
-    $stocksSorties = $query->orderBy('date_sortie', 'desc')
+    // Récupération des sorties de stock triées par date_sortie DESC
+    $stocksSorties = StocksSorties::with(['produit', 'user'])
+        ->orderBy('date_sortie', 'desc')
         ->orderBy('numero_bon', 'desc')
         ->get();
 
@@ -113,16 +38,16 @@ public function index(Request $request)
             'nombre_produits' => $sorties->count(),
             'user' => $firstSortie->user,
             'id' => $firstSortie->id,
-            'numero_ordre' => $firstSortie->numero_ordre, 
+             'numero_ordre' => $firstSortie->numero_ordre,
         ];
     }
 
-    // Tri final
+    // Tri final du tableau des bons par date_sortie desc (et éventuellement numero_bon desc)
     usort($bonsSortie, function ($a, $b) {
         return strcmp($b['date_sortie'], $a['date_sortie']) ?: strcmp($b['numero_bon'], $a['numero_bon']);
     });
 
-    // Produits avec stock
+    // Produits avec des stocks disponibles
     $produitsAvecStock = Produit::whereHas('stocksEntrees', function ($query) {
         $query->select('produit_id')->groupBy('produit_id');
     })->get()->filter(function ($produit) {
@@ -137,7 +62,7 @@ public function index(Request $request)
         return ($entree->quantite - $totalSortie) > 0;
     });
 
-    // Numéro automatique
+    // Numéro automatique du bon
     $numeroBon = $this->genererNumeroBon();
 
     return view('stocksSorties.index', [
@@ -148,6 +73,82 @@ public function index(Request $request)
         'id' => $bonsSortie[0]['id'] ?? null,
     ]);
 }
+
+// public function index(Request $request)
+// {
+//     $mois = $request->input('mois', now()->month); // mois courant par défaut
+//     $statut = $request->input('statut');
+//     $utilisateur = $request->input('utilisateur');
+
+//     $query = StocksSorties::with(['produit', 'user']);
+
+//     // Filtrer par mois
+//     $query->whereMonth('date_sortie', $mois);
+
+//     // Filtrer par statut si fourni
+//     if (!empty($statut)) {
+//         $query->where('statut', $statut);
+//     }
+
+//     // Filtrer par utilisateur actuel si demandé
+//     if ($utilisateur === 'moi') {
+//         $query->where('user_id', Auth::id());
+//     }
+
+//     $stocksSorties = $query->orderBy('date_sortie', 'desc')
+//         ->orderBy('numero_bon', 'desc')
+//         ->get();
+
+//     // Groupement par numéro de bon
+//     $stocksSortiesGroupes = $stocksSorties->groupBy('numero_bon');
+
+//     $bonsSortie = [];
+
+//     foreach ($stocksSortiesGroupes as $bon => $sorties) {
+//         $firstSortie = $sorties->first();
+
+//         $bonsSortie[] = [
+//             'numero_bon' => $bon,
+//             'date_sortie' => $firstSortie->date_sortie,
+//             'statut' => $firstSortie->statut,
+//             'nombre_produits' => $sorties->count(),
+//             'user' => $firstSortie->user,
+//             'id' => $firstSortie->id,
+//             'numero_ordre' => $firstSortie->numero_ordre, 
+//         ];
+//     }
+
+//     // Tri final
+//     usort($bonsSortie, function ($a, $b) {
+//         return strcmp($b['date_sortie'], $a['date_sortie']) ?: strcmp($b['numero_bon'], $a['numero_bon']);
+//     });
+
+//     // Produits avec stock
+//     $produitsAvecStock = Produit::whereHas('stocksEntrees', function ($query) {
+//         $query->select('produit_id')->groupBy('produit_id');
+//     })->get()->filter(function ($produit) {
+//         $totalEntree = StocksEntrees::where('produit_id', $produit->id)->sum('quantite');
+//         $totalSortie = StocksSorties::where('produit_id', $produit->id)->sum('quantite');
+//         return ($totalEntree - $totalSortie) > 0;
+//     });
+
+//     // Lots disponibles
+//     $stocksEntreesDisponibles = StocksEntrees::with('produit')->get()->filter(function ($entree) {
+//         $totalSortie = StocksSorties::where('stock_entree_id', $entree->id)->sum('quantite');
+//         return ($entree->quantite - $totalSortie) > 0;
+//     });
+
+//     // Numéro automatique
+//     $numeroBon = $this->genererNumeroBon();
+
+//     return view('stocksSorties.index', [
+//         'stocksSorties' => $bonsSortie,
+//         'produits' => $produitsAvecStock,
+//         'stocksEntrees' => $stocksEntreesDisponibles,
+//         'numeroBon' => $numeroBon,
+//         'id' => $bonsSortie[0]['id'] ?? null,
+//     ]);
+// }
 
     /**
      * Show the form for creating a new resource.

--- a/public/js/stocksEntrees/EntreeEditionShow.js
+++ b/public/js/stocksEntrees/EntreeEditionShow.js
@@ -49,9 +49,58 @@ document.addEventListener('DOMContentLoaded', () => {
         //Attendre 2 secondes avant de recharger la page
         setTimeout(() => {
           window.location.reload();
-        }, 2000); // 2000 ms = 2 secondes
+        }, 2500); // 2000 ms = 2 secondes
 
       })
+//       .then(data => {
+//   // Fermer le modal
+//   const modalEl = document.getElementById('editEntreeModal');
+//   if (modalEl) {
+//     bootstrap.Modal.getOrCreateInstance(modalEl).hide();
+//     setTimeout(forceCleanModal, 350);
+//   }
+
+//   // ✅ Mettre à jour le bouton "modifier"
+//   const editButton = document.querySelector(`.edit-entree-btn[data-id="${data.id}"]`);
+//   if (editButton) {
+//     editButton.dataset.quantite = data.quantite;
+//     editButton.dataset.date = data.date_expiration;
+//   }
+
+//   // Mettre à jour les champs dans la page (DOM)
+//   const quantiteEl = document.querySelector('.card-body div.col-md-4:nth-child(3)');
+//   if (quantiteEl) {
+//     quantiteEl.innerHTML = `<strong>Quantité :</strong> ${parseInt(data.quantite).toLocaleString('fr-FR')}`;
+//   }
+
+//   const dateExpirationEl = document.querySelectorAll('.card-body div.col-md-4')[4]; // attention à l'ordre
+//   if (dateExpirationEl) {
+//     const formattedDate = new Date(data.date_expiration).toLocaleDateString('fr-FR', {
+//       year: 'numeric',
+//       month: 'long',
+//       day: 'numeric',
+//     });
+//     dateExpirationEl.innerHTML = `<strong>Date d'expiration :</strong> ${formattedDate}`;
+//   }
+
+//   // Mettre à jour le stock restant
+//   const sorties = parseInt(document.querySelector('[data-total-sorties]')?.dataset.totalSorties || 0); // facultatif
+//   const stockRestant = parseInt(data.quantite) - sorties;
+
+//   const stockRestantEl = document.querySelector('.card-body div.col-md-4:nth-child(6) span');
+//   if (stockRestantEl) {
+//     stockRestantEl.innerText = stockRestant.toLocaleString('fr-FR');
+//     if (stockRestant <= 0) {
+//       stockRestantEl.classList.add('text-danger', 'fw-bold');
+//     } else {
+//       stockRestantEl.classList.remove('text-danger', 'fw-bold');
+//     }
+//   }
+
+//   // Afficher succès
+//   showSuccessAlert('update', 'entrée');
+// });
+
       .catch(error => {
         alert(error.message);
         console.error("Erreur lors de la modification de l'entrée :", error);

--- a/public/js/stocksEntrees/filtreEntree.js
+++ b/public/js/stocksEntrees/filtreEntree.js
@@ -8,12 +8,12 @@
         const tbody = document.querySelector('#stocksEntreesTable tbody');
 
         if (!tbody) return;
-
+        
+        const allRows = Array.from(tbody.querySelectorAll('.entree-row')).map(row => row.cloneNode(true));
         // Injecté via Blade dans <body data-current-user-id="{{ auth()->id() }}">
         const currentUserId = document.body.dataset.currentUserId;
 
         // Cloner toutes les lignes au chargement
-        const allRows = Array.from(tbody.querySelectorAll('.entree-row')).map(row => row.cloneNode(true));
 
         const emptyRow = document.createElement('tr');
         emptyRow.id = 'emptyRow';

--- a/public/js/stocksSorties/filtreSortie.js
+++ b/public/js/stocksSorties/filtreSortie.js
@@ -14,7 +14,7 @@
         const emptyRow = document.createElement('tr');
         emptyRow.id = 'emptyRow';
         emptyRow.innerHTML = `
-            <td colspan="6" class="text-center text-muted py-4">
+            <td colspan="7" class="text-center text-muted py-4">
                 <i class="bi bi-inbox me-2 fs-5"></i> Aucun résultat trouvé.
             </td>`;
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -99,7 +99,7 @@
 
   <!-- Stocks Entrées -->
   <script src="{{ asset('js/stocksEntrees/EntreeCreation.js') }}"></script>
-  <script src="{{ asset('js/stocksEntrees/EntreeEdition.js') }}"></script>
+  <script src="{{ asset('js/stocksEntrees/EntreeEditionShow.js') }}"></script>
   <script src="{{ asset('js/stocksEntrees/ChoixUnite.js') }}"></script>
   <script src="{{ asset('js/stocksEntrees/filtreEntree.js') }}"></script>
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -106,7 +106,7 @@
   <!-- Stocks Sorties -->
   <script src="{{ asset('js/stocksSorties/AjoutProduitBS.js') }}"></script>
   <script src="{{ asset('js/stocksSorties/BScreation.js') }}"></script>
-  <script src="{{ asset('js/stocksSorties/RechercheEtFiltrage.js') }}"></script>
+  <script src="{{ asset('js/stocksSorties/filtreSortie.js') }}"></script>
   <script src="{{ asset('js/stocksSorties/ChoixUnite.js') }}"></script>
 
   <!-- Impression personnalisée -->

--- a/resources/views/stocksEntrees/index.blade.php
+++ b/resources/views/stocksEntrees/index.blade.php
@@ -6,7 +6,7 @@
 @section('content')
 <div class="container-fluid py-2">
     <!-- En-tête -->
-    <div class="d-flex justify-content-between align-items-center mb-4">
+    <div class="d-flex justify-content-between align-items-center mb-2">
         <h5 class="mb-0">
             <i class="bi bi-box-arrow-in-down"></i> Entrées en Stock
         </h5>

--- a/resources/views/stocksEntrees/listeStocksEntrees.blade.php
+++ b/resources/views/stocksEntrees/listeStocksEntrees.blade.php
@@ -63,7 +63,7 @@
                 </tr>
             @empty
                 <tr>
-                    <td colspan="8" class="text-center text-muted py-4">
+                    <td colspan="10" class="text-center text-muted py-4">
                         <i class="bi bi-inbox me-2 fs-5"></i> Aucune entrée enregistrée.
                     </td>
                 </tr>

--- a/resources/views/stocksEntrees/show.blade.php
+++ b/resources/views/stocksEntrees/show.blade.php
@@ -34,21 +34,40 @@
             <div class="row g-3">
                 <div class="col-md-4"><strong>Numéro de Lot :</strong> {{ $stockEntree->numero_lot }}</div>
                 <div class="col-md-4"><strong>Produit :</strong> {{ $stockEntree->produit?->nom ?? '-' }}</div>
-                <div class="col-md-4"><strong>Quantité :</strong> {{ number_format($stockEntree->quantite, 0, ',', ' ') }}</div>
+                <!-- <div class="col-md-4"><strong>Quantité :</strong> {{ number_format($stockEntree->quantite, 0, ',', ' ') }}</div> -->
+                <div class="col-md-4"><strong>Quantité :</strong> <span id="quantite_affichee">{{ number_format($stockEntree->quantite, 0, ',', ' ') }}</span></div>
 
                 <div class="col-md-4"><strong>Date d'entrée :</strong> {{ \Carbon\Carbon::parse($stockEntree->date_entree)->translatedFormat('d F Y') }}</div>
-                <div class="col-md-4">
+                <!-- <div class="col-md-4">
                     <strong>Date d'expiration :</strong> 
                     @if ($stockEntree->date_expiration)
                         {{ \Carbon\Carbon::parse($stockEntree->date_expiration)->translatedFormat('d F Y') }}
                     @else
                         <span class="badge bg-secondary">-</span>
                     @endif
-                </div>
+                </div> -->
                 <div class="col-md-4">
+                  <strong>Date d'expiration :</strong>
+                  <span id="expiration_affichee">
+                    @if ($stockEntree->date_expiration)
+                      {{ \Carbon\Carbon::parse($stockEntree->date_expiration)->translatedFormat('d F Y') }}
+                    @else
+                      <span class="badge bg-secondary">-</span>
+                    @endif
+                  </span>
+                </div>
+
+                <!-- <div class="col-md-4">
                     <strong>Stock restant :</strong> 
                     <span class="{{ ($stockEntree->quantite - $stockEntree->stocksSorties->sum('quantite')) <= 0 ? 'text-danger fw-bold' : '' }}">
                         {{ number_format($stockEntree->quantite - $stockEntree->stocksSorties->sum('quantite'), 0, ',', ' ') }}
+                    </span>
+                </div> -->
+                <div class="col-md-4">
+                    <strong>Stock restant :</strong>
+                    <span id="stock_restant" data-total-sorties="{{ $stockEntree->stocksSorties->sum('quantite') }}"
+                    class="{{ ($stockEntree->quantite - $stockEntree->stocksSorties->sum('quantite')) <= 0 ? 'text-danger fw-bold' : '' }}">
+                    {{ number_format($stockEntree->quantite - $stockEntree->stocksSorties->sum('quantite'), 0, ',', ' ') }}
                     </span>
                 </div>
 

--- a/resources/views/stocksSorties/filtreSortie.blade.php
+++ b/resources/views/stocksSorties/filtreSortie.blade.php
@@ -11,15 +11,23 @@
     <!-- Mois -->
     <div class="flex-grow-1 min-w-150">
       <label for="filtreMois" class="form-label small mb-1">Mois</label>
-      @php $moisSelectionne = request('mois', now()->month); @endphp
+      <!--@php $moisSelectionne = request('mois', now()->month); @endphp
       <select id="filtreMois" name="mois" class="form-select form-select-sm">
-        <option value="">Tous</option>
+        <option value="">Tous les mois</option>
         @foreach(range(1, 12) as $mois)
           <option value="{{ $mois }}" {{ $mois == $moisSelectionne ? 'selected' : '' }}>
             {{ ucfirst(\Carbon\Carbon::create()->month($mois)->locale('fr')->translatedFormat('F')) }}
           </option>
         @endforeach
-      </select>
+      </select> -->
+      <select id="filtreMois" name="mois" class="form-select form-select-sm">
+      <option value="">Tous les mois</option>
+      @foreach (range(1, 12) as $mois)
+        <option value="{{ $mois }}" {{ $mois == now()->month ? 'selected' : '' }}>
+          {{ ucfirst(\Carbon\Carbon::create()->month($mois)->locale('fr')->translatedFormat('F')) }}
+        </option>
+      @endforeach
+    </select>
     </div>
 
     <!-- Statut -->

--- a/resources/views/stocksSorties/listeStocksSorties.blade.php
+++ b/resources/views/stocksSorties/listeStocksSorties.blade.php
@@ -45,7 +45,7 @@
             </tr>
         @empty
             <tr id="emptyRow">
-                <td colspan="6" class="text-center text-muted py-4">
+                <td colspan="7" class="text-center text-muted py-4">
                     <i class="bi bi-inbox me-2 fs-5"></i> Aucune sortie enregistrée.
                 </td>
             </tr>


### PR DESCRIPTION
## 🎯 Fonctionnalité : Affichage détaillé d’un fournisseur

Cette PR ajoute une nouvelle vue permettant d'afficher les détails d’un fournisseur, ainsi que les produits qu’il a fournis via les entrées en stock.

### ✅ Changements principaux

- Création de la vue `fournisseurs/show.blade.php` pour afficher :
  - Informations du fournisseur (nom, téléphone, email, adresse, statut)
  - Tableau listant tous les produits fournis (via les lots de stock)
- Ajout d’un bouton de modification qui ouvre une **fenêtre modale**
- Intégration du **formulaire d’édition du fournisseur dans une modal**
- Ajout d’un script JavaScript pour pré-remplir les champs de la modal

### 🧪 À tester

- Vérifier l’affichage correct des données du fournisseur
- Tester l’ouverture de la modal de modification
- Vérifier que les champs sont bien pré-remplis
- Tester la soumission du formulaire de modification

---

> Branche : `fix/fournisseur`
> Type : Amélioration UI + ajout de fonctionnalité
